### PR TITLE
Hotfix/admin control navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ var handleIframePostMessage = (e) => {
 var handleUnload = (e) => {
     const focusedElement = $(':focus')[0]
     const destination = focusedElement ? focusedElement.href : null
-    if (destination && destination.includes('/admin') && (!destination.includes('/admin/Site') || !destination.includes('/admin/Control'))) {
+    if (destination && destination.includes('/admin') && !(destination.includes('/admin/Site') || destination.includes('/admin/Control'))) {
         console.debug(`%c [ADMIN CATALOG JS] \n Will navigate to other domain: ${destination}`, 'background: #002833; color: #258bd2')
         window.top.postMessage({
             type: 'admin.absoluteNavigation',

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ var handleIframePostMessage = (e) => {
 var handleUnload = (e) => {
     const focusedElement = $(':focus')[0]
     const destination = focusedElement ? focusedElement.href : null
-    if (destination && destination.includes('/admin') && !destination.includes('/admin/Site')) {
+    if (destination && destination.includes('/admin') && (!destination.includes('/admin/Site') || !destination.includes('/admin/Control'))) {
         console.debug(`%c [ADMIN CATALOG JS] \n Will navigate to other domain: ${destination}`, 'background: #002833; color: #258bd2')
         window.top.postMessage({
             type: 'admin.absoluteNavigation',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-iframe-compatibility",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Compatiblity js to adapt catalog admin to iframe",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-iframe-compatibility",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Compatiblity js to adapt catalog admin to iframe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes cases where `/admin/Control` navigates absolutelly instead of inside iframe. Example: Attach global category in category form.